### PR TITLE
Add loop_index

### DIFF
--- a/minijanus.js
+++ b/minijanus.js
@@ -11,8 +11,8 @@ function JanusPluginHandle(session) {
 }
 
 /** Attaches this handle to the Janus server and sets its ID. **/
-JanusPluginHandle.prototype.attach = function(plugin) {
-  var payload = { plugin: plugin, "force-bundle": true, "force-rtcp-mux": true };
+JanusPluginHandle.prototype.attach = function(plugin, loop_index) {
+  var payload = { plugin: plugin, loop_index, "force-bundle": true, "force-rtcp-mux": true };
   return this.session.send("attach", payload).then(resp => {
     this.id = resp.data.id;
     return resp;

--- a/minijanus.js
+++ b/minijanus.js
@@ -12,7 +12,10 @@ function JanusPluginHandle(session) {
 
 /** Attaches this handle to the Janus server and sets its ID. **/
 JanusPluginHandle.prototype.attach = function(plugin, loop_index) {
-  var payload = { plugin: plugin, loop_index: loop_index, "force-bundle": true, "force-rtcp-mux": true };
+  var payload = { plugin: plugin, "force-bundle": true, "force-rtcp-mux": true };
+  if(loop_index) {
+    payload.loop_index = loop_index;
+  }
   return this.session.send("attach", payload).then(resp => {
     this.id = resp.data.id;
     return resp;

--- a/minijanus.js
+++ b/minijanus.js
@@ -12,10 +12,7 @@ function JanusPluginHandle(session) {
 
 /** Attaches this handle to the Janus server and sets its ID. **/
 JanusPluginHandle.prototype.attach = function(plugin, loop_index) {
-  var payload = { plugin: plugin, "force-bundle": true, "force-rtcp-mux": true };
-  if(loop_index) {
-    payload.loop_index = loop_index;
-  }
+  var payload = { plugin: plugin, loop_index: loop_index, "force-bundle": true, "force-rtcp-mux": true };
   return this.session.send("attach", payload).then(resp => {
     this.id = resp.data.id;
     return resp;

--- a/minijanus.js
+++ b/minijanus.js
@@ -12,7 +12,7 @@ function JanusPluginHandle(session) {
 
 /** Attaches this handle to the Janus server and sets its ID. **/
 JanusPluginHandle.prototype.attach = function(plugin, loop_index) {
-  var payload = { plugin: plugin, loop_index, "force-bundle": true, "force-rtcp-mux": true };
+  var payload = { plugin: plugin, loop_index: loop_index, "force-bundle": true, "force-rtcp-mux": true };
   return this.session.send("attach", payload).then(resp => {
     this.id = resp.data.id;
     return resp;


### PR DESCRIPTION
Allows minijanus to specify a loop index as documented in https://github.com/meetecho/janus-gateway/blob/master/conf/janus.jcfg.sample.in#L108